### PR TITLE
Add a docker-compose.yml file for development purposes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
-/dist
-/node_modules
-.github
+/.github/
+/.nyc_output/
+/dist/
+/node_modules/
+/.dockerignore
+/.gitignore
+/docker-compose.yml
+/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+
+  noether:
+    container_name: noether
+    build:
+      context: .
+      target: base
+    command: tail -f /dev/null
+    volumes:
+      - .:/app
+    working_dir: /app


### PR DESCRIPTION
Hi!

I though that it could be convenient to allow contributors the option to work with a `docker-compose.yml` file. Doing so ensures the developer works with the same node version as the one used in production.

No more yarn needed on the developer machine, just `docker exec -ti noether sh` to get a shell access and easily run tests, etc...

I also updated the `.dockerignore` file to ignore the `docker-compose.yml` that will not be needed in the Docker image, as well as other files and dirs that could also be added.

Regarding the compose file, we could also name it `docker-compose.dev.yml` or `docker-compose-dev.yml` if you think the current name could lead to confusion for standard users, but it would mean a more verbose command to bootstrap the contributor environment:
`docker-compose up -d -c docker-compose.dev.yml` instead of the simpler `docker-compose up -d`.

Please tell me if you have any question or you would like to see more improvement to the work I've done. Thanks!