### PR TITLE
Read wallet password from env variable

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -68,15 +68,15 @@ export const loadFromFile = async (
         // load wallet from file
         const json = fs.readFileSync(filename, "utf-8");
 
-        // read password from stdin
-        const password = await prompts({
+        // if CTSI_WALLET_PASSWORD env variable not set read from stdin
+        const password = process.env.CTSI_WALLET_PASSWORD ? process.env.CTSI_WALLET_PASSWORD : (await prompts({
             type: "password",
             name: "value",
             message: "password",
-        });
+        })).value;
 
         // load wallet
-        return Wallet.fromEncryptedJson(json, password.value);
+        return Wallet.fromEncryptedJson(json, password);
     }
 };
 


### PR DESCRIPTION
To be cloud native, the application shouldn't require interactive input, like typing the wallet password at the beginning. This change would allow the container to run in kubernetes. Passing a password via env variable is the safe industry standard.

The change is backward compatible. If `CTSI_WALLET_PASSWORD` is not set we are still asking for the user input.

TESTS:
- Launched the validator without `CTSI_WALLET_PASSWORD` set => It sill ask for the password and runs correctly after typed.
- Launched the validator with `CTSI_WALLET_PASSWORD` set => Runs correctly without asking for the password