### PR TITLE
feat: add rebalance interval

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ import { parseEther } from "@ethersproject/units";
 export const TIMEOUT = 24 * 60 * 60 * 1000;
 export const RETRY_INTERVAL = 10000;
 export const POLLING_INTERVAL = 30000;
+export const REBALANCE_INTERVAL = 0;
 export const CONFIRMATIONS = 1;
 export const CONFIRMATION_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 export const GAS_LIMIT_MULTIPLIER = 160;

--- a/src/pos/client.ts
+++ b/src/pos/client.ts
@@ -300,8 +300,10 @@ export class PoolProtocolImpl extends AbstractProtocolClient {
 
             // increment rebalance counter
             monitoring.rebalance.inc();
+
+            return true;
         }
 
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
### Description of the changes

This PR adds a new—very simple—strategy to manage how often `rebalance()` calls are made by the node while it is running.
This strategy could be the first of many to manage rebalance calls. The goal here was to get a first working prototype for this type of feature.

The rebalance minimum interval can be configured with the `REBALANCE_INTERVAL` configurtation. The flaw of current implementation is that the counter is reset on node restart. This could be improved by fetching the last time a rebalance call happened on the blockchain on node startup.