### PR TITLE
Add rebalanceInterval param to reduce pool rebalances per day

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Noether command line provides the following options:
 | --accountIndex     |                      | 0                     | Account index from server to use |
 | --gasPrice         | GAS_PRICE_PROVIDER   | eth-provider          | Gas price predictor strategy     |
 | --gasStationAPIKey | GAS_STATION_API_KEY  |                       |                                  |
+| --rebalanceInterval| REBALANCE_INTERVAL   | 0                     | Min rebalance interval in mins   |
 
 ### Gas price
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,8 @@ export const app = async (
     hostname: string,
     port: number,
     gasPriceProviderType: GasPriceProviderType,
-    gasStationAPIKey: string | undefined
+    gasStationAPIKey: string | undefined,
+    rebalanceInterval: number
 ) => {
     // connect to node
     const { address, network, pos, provider, workerManager } = await connect(
@@ -101,7 +102,7 @@ export const app = async (
 
     // create protocol client (smart contract communication)
     const client: ProtocolClient = pool
-        ? new PoolProtocolImpl(pos, user, workerManager, gasPriceProvider)
+        ? new PoolProtocolImpl(pos, user, workerManager, gasPriceProvider, rebalanceInterval)
         : new ProtocolImpl(pos, workerManager, gasPriceProvider);
 
     // create block producer

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -26,6 +26,7 @@ interface Args {
     port: number;
     gasPrice: GasPriceProviderType;
     gasStationAPIKey: string;
+    rebalanceInterval: number;
     verbose: boolean;
 }
 
@@ -55,6 +56,10 @@ export const builder = (yargs: Argv) => {
         .option("gasStationAPIKey", {
             describe: "Gas Station API Key",
             default: process.env.GAS_STATION_API_KEY,
+        })
+        .option("rebalanceInterval", {
+            describe: "Rebalance interval in minutes",
+            default: process.env.REBALANCE_INTERVAL || 0,
         })
         .option("create", {
             describe: "Create a wallet if it doesn't exist",
@@ -96,6 +101,7 @@ export const handler = (args: Args) => {
         args.hostname,
         args.port,
         args.gasPrice,
-        args.gasStationAPIKey
+        args.gasStationAPIKey,
+        args.rebalanceInterval
     );
 };


### PR DESCRIPTION
We want to rebalance less frequently than 6 hours to optimize costs. Ideally this interval can be set to 48 hours. By default the interval is 0 and there are no changes to the current behavior.

TESTS
This has been tested for a while by the omnistake pool with no regressions on the performance and user experience.